### PR TITLE
Make camel_case behavior match play-json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.sbt.SbtScalariform.{ScalariformKeys, autoImport}
 val projectName = "play-json-extensions"
 lazy val root = Project(id = projectName, base = file("."))
 
-version := "0.42.0"
+version := "0.42.1-SNAPSHOT"
 organization := "ai.x"
 name := projectName
 scalaVersion := "2.12.10"

--- a/src/main/scala/play-json.scala
+++ b/src/main/scala/play-json.scala
@@ -476,14 +476,7 @@ object implicits {
 final case class SingletonEncoder( apply: java.lang.Class[_] => JsValue )
 object SingletonEncoder {
   import scala.reflect.NameTransformer
-  def camel2underscore( str: String ) = (
-    str.take( 1 )
-    ++
-    "[0-9A-Z]".r.replaceAllIn(
-      str.drop( 1 ),
-      "_" + _.group( 0 ).toLowerCase
-    )
-  )
+  def camel2underscore( str: String ): String = JsonNaming.SnakeCase( str )
   def decodeName( name: String ) = NameTransformer.decode( name.dropRight( 1 ) )
   implicit def simpleName = SingletonEncoder( cls => JsString( decodeName( cls.getSimpleName ) ) )
   implicit def simpleNameLowerCase = SingletonEncoder( cls => JsString( camel2underscore( decodeName( cls.getSimpleName ) ) ) )
@@ -499,14 +492,7 @@ case class BaseNameEncoder() extends NameEncoder {
 }
 
 case class CamelToSnakeNameEncoder() extends NameEncoder {
-  override def encode( str: String ): String = (
-    str.take( 1 ).toLowerCase
-    ++
-    "[0-9A-Z]".r.replaceAllIn(
-      str.drop( 1 ),
-      "_" + _.group( 0 ).toLowerCase
-    )
-  )
+  override def encode( str: String ): String = JsonNaming.SnakeCase( str )
 }
 
 object Encoders {


### PR DESCRIPTION
Update to use the play-json snake case function rather than the built-in one that does not match.

Fixes #82
