### PR TITLE
Fix warning about generated unused value in macro

### DIFF
--- a/src/main/scala/play-json.scala
+++ b/src/main/scala/play-json.scala
@@ -300,7 +300,10 @@ private[json] class Macros( val c: blackbox.Context ) {
             val result = if(bpath.isInstanceOf[$pjson.JsDefined]) $result else ${orDefault( result, k )}
             (resolved,result) match {
               case (_,result:$pjson.JsSuccess[_]) => result
-              case _ => resolved.flatMap(_ => result)
+              case _ => resolved.flatMap { unused =>
+                val _ = unused
+                result
+              }
             }
           }
           """ )


### PR DESCRIPTION
Fixes #84 
For some reason, this part of the macro get's expanded out to something like:
```scala
case _ => resolved.flatMap(((x$17) => result))
```
And then the compiler complains about `x$17` being unused, even though it generated it :/
Seems more like a compiler/macro bug, but this is a workaround that fixes it.