### PR TITLE
Bump up Scala, SBT, and Play versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ lazy val root = Project(id = projectName, base = file("."))
 version := "0.42.0"
 organization := "ai.x"
 name := projectName
-scalaVersion := "2.12.10"
-crossScalaVersions := Seq("2.12.10", "2.13.1")
+scalaVersion := "2.12.17"
+crossScalaVersions := Seq("2.12.17", "2.13.10")
 useGpg := true
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
 description := "Additional type classes for the play-json serialization library"
@@ -31,9 +31,9 @@ developers := List(
 )
 
 libraryDependencies ++=   Seq(
-  "com.typesafe.play" %% "play-json" % "2.8.1",
+  "com.typesafe.play" %% "play-json" % "2.9.3",
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.2.14" % "test"
 )
 
 resolvers ++= Seq(

--- a/build/build.properties
+++ b/build/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.7.3

--- a/src/main/scala/play-json.scala
+++ b/src/main/scala/play-json.scala
@@ -67,7 +67,7 @@ package object internals {
           b += elem
         }
       }
-      b.result
+      b.result()
     }
   }
 }
@@ -197,7 +197,7 @@ private[json] class Macros( val c: blackbox.Context ) {
         """
       } else if ( isCaseClass( T ) && caseClassFieldsTypes( T ).size == 1 ) {
         val ArgType = caseClassFieldsTypes( T ).head._2
-        val name = TermName( c.freshName )
+        val name = TermName( c.freshName() )
         q"""
         implicit def $name = $pkg.Jsonx.formatAuto[$ArgType]
         $pkg.Jsonx.formatInline[$T]
@@ -206,7 +206,7 @@ private[json] class Macros( val c: blackbox.Context ) {
         val fieldFormatters = caseClassFieldsTypes( T ).map {
           case ( _, t ) => t
         }.toVector.distinctWith( _ =:= _ ).map { t =>
-          val name = TermName( c.freshName )
+          val name = TermName( c.freshName() )
           q"implicit def $name = $pkg.Jsonx.formatAuto[$t]"
         }
         val t = q"""
@@ -216,7 +216,7 @@ private[json] class Macros( val c: blackbox.Context ) {
         t
       } else if ( T.typeSymbol.isClass && T.typeSymbol.asClass.isSealed && T.typeSymbol.asClass.isAbstract ) {
         val fieldFormatters = T.typeSymbol.asClass.knownDirectSubclasses.map { t =>
-          val name = TermName( c.freshName )
+          val name = TermName( c.freshName() )
           q"implicit def $name = Jsonx.formatAuto[$t]"
         }
         q"""
@@ -286,7 +286,7 @@ private[json] class Macros( val c: blackbox.Context ) {
     }
     val ( results, mkResults ) = caseClassFieldsTypes( T ).map {
       case ( k, t ) =>
-        val name = TermName( c.freshName )
+        val name = TermName( c.freshName() )
         val path = q"""(json \ (encoder.encode($k)))"""
         val result = q"""{
           import $pkg._

--- a/src/test/scala/PlayJsonExtensionsTest.scala
+++ b/src/test/scala/PlayJsonExtensionsTest.scala
@@ -1,13 +1,10 @@
 package ai.x.test.play.json
 
-import org.scalatest.FunSuite
-
 import _root_.play.api.libs.json._
-
 import ai.x.play.json._
 import ai.x.play.json.tuples._
-
 import ai.x.play.json.Encoders._
+import org.scalatest.funsuite.AnyFunSuite
 
 final case class RecursiveClass( o: Option[RecursiveClass], s: String )
 object RecursiveClass {
@@ -62,7 +59,7 @@ case class Ua( i: Int ) extends OP
 case class Unknown( json: JsValue ) extends OP
 case class Uzzzzzzz( s: String ) extends OP
 
-class PlayJsonExtensionsTest extends FunSuite {
+class PlayJsonExtensionsTest extends AnyFunSuite {
   test( "de/serialize symbol fields" ) {
     case class SymbolFieldsClass( ### :Int, $$$: Double, %%% : Boolean, -+-+ : Seq[Int] )
     implicit val fmt1 = Jsonx.formatCaseClass[SymbolFieldsClass]
@@ -332,7 +329,7 @@ abstract class JsonTestClasses {
   case class ClassOuter2( outer: List[ListOuter2] )
   object ClassOuter2 { implicit def jsonFormat = Jsonx.formatCaseClass[ClassOuter2] }
 }
-class JsonTests extends FunSuite {
+class JsonTests extends AnyFunSuite {
   test( "json optionWithNull" ) {
     object JsonTestClasses extends JsonTestClasses {
       implicit def option[A]( implicit reads: Reads[A] ): Reads[Option[A]] = implicits.optionWithNull[A]


### PR DESCRIPTION
- [x] Bump up Scala versions to 2.12.17 and 2.13.10 versions
- [x] Bump up Play to the 2.9.3 version
- [x] Bump up SBT to 1.73 version
- [x] Bump up Scalatest to 3.2.14 version 
- [x] Fix breaking changes in tests and impl. code 